### PR TITLE
Improve Platform Event Channels query

### DIFF
--- a/src/main/default/classes/StreamingMonitorController.cls
+++ b/src/main/default/classes/StreamingMonitorController.cls
@@ -219,16 +219,14 @@ public abstract class StreamingMonitorController {
         List<EntityDefinition> entities = [
             SELECT Label, QualifiedApiName, IsCustomizable
             FROM EntityDefinition
-            WHERE IsCustomizable = TRUE AND QualifiedApiName LIKE '%e'
+            WHERE KeyPrefix LIKE 'e%'
             ORDER BY Label ASC
         ];
         List<ComboBoxItem> items = new List<ComboBoxItem>();
         for (EntityDefinition entity : entities) {
-            if (entity.QualifiedApiName.endsWith('__e')) {
-                items.add(
-                    new ComboBoxItem(entity.Label, entity.QualifiedApiName)
-                );
-            }
+            items.add(
+                new ComboBoxItem(entity.Label, entity.QualifiedApiName)
+            );
         }
         return items;
     }


### PR DESCRIPTION
I believe Platform Event channels entities start with an `e` (KeyPrefix in EntityDefinition).

So instead of querying all entities with QualifiedApiName ending with and `e` and then excluding the records that are not platform events, it should be more efficient to simply query entities with KeyPrefix starting by `e`.